### PR TITLE
Revamp portfolio: real projects, blog & refreshed design

### DIFF
--- a/app/about/layout.tsx
+++ b/app/about/layout.tsx
@@ -4,10 +4,8 @@ export default function AboutLayout({
   children: React.ReactNode;
 }) {
   return (
-    <section className="flex flex-col items-center justify-center gap-4 py-8 md:py-10">
-      <div className="inline-block max-w-lg text-center justify-center">
-        {children}
-      </div>
+    <section className="mx-auto w-full max-w-3xl px-6 py-14 sm:py-20">
+      {children}
     </section>
   );
 }

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,9 +1,63 @@
-import { title } from "@/components/primitives";
+import { Metadata } from "next";
+import { Link } from "@nextui-org/link";
+
+import { Prose } from "@/components/prose";
+import { siteConfig } from "@/config/site";
+
+export const metadata: Metadata = {
+  title: "About",
+  description:
+    "Samy Layaida — full-stack software engineer in Paris who builds web products and self-hosts the infrastructure behind them.",
+};
 
 export default function AboutPage() {
   return (
     <div>
-      <h1 className={title()}>About</h1>
+      <header className="max-w-2xl">
+        <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary">
+          About
+        </p>
+        <h1 className="mt-3 text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+          Hi, I&apos;m Samy.
+        </h1>
+      </header>
+
+      <div className="mt-10">
+        <Prose>
+          <p className="lead">
+            I&apos;m a full-stack software engineer based in Paris. I like
+            taking an idea all the way from an empty repo to something people
+            actually use — and then owning the boring parts that keep it
+            running.
+          </p>
+          <p>
+            Most of my work lives in the TypeScript / React / Next.js world,
+            with Node, PHP/Symfony and a few SQL and NoSQL databases behind it.
+            Lately a lot of my energy goes into <strong>LifeOS</strong>, a
+            self-hosted hub that pulls health, habits, work and finances into
+            one place I fully control.
+          </p>
+          <p>
+            Outside of app code, I run a <strong>homelab</strong>: a stack of
+            self-hosted services behind a Cloudflare tunnel, with Prometheus and
+            Grafana watching over it and a good amount of Docker holding it all
+            together. It&apos;s where I learn the infrastructure side of the
+            craft by breaking and fixing real things.
+          </p>
+          <p>
+            This site is also where I write — mostly debugging stories and
+            self-hosting notes, the kind of thing I wish I&apos;d found when I
+            hit the problem myself.
+          </p>
+          <p>
+            Want to build something, or just compare homelab notes?{" "}
+            <Link className="text-primary" href={siteConfig.links.contact}>
+              Get in touch
+            </Link>
+            .
+          </p>
+        </Prose>
+      </div>
     </div>
   );
 }

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,89 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Link } from "@nextui-org/link";
+import { FaArrowLeft } from "react-icons/fa";
+
+import { posts, getPost, formatDate } from "@/config/posts";
+
+export function generateStaticParams() {
+  return posts.map((p) => ({ slug: p.slug }));
+}
+
+export function generateMetadata({
+  params,
+}: {
+  params: { slug: string };
+}): Metadata {
+  const post = getPost(params.slug);
+
+  if (!post) return {};
+
+  return {
+    title: post.title,
+    description: post.description,
+    openGraph: {
+      title: post.title,
+      description: post.description,
+      type: "article",
+      publishedTime: post.date,
+    },
+  };
+}
+
+export default function PostPage({ params }: { params: { slug: string } }) {
+  const post = getPost(params.slug);
+
+  if (!post) notFound();
+
+  const { Content } = post;
+
+  return (
+    <article className="mx-auto max-w-2xl">
+      <Link
+        className="group inline-flex items-center gap-2 font-mono text-sm text-default-500 hover:text-primary"
+        href="/blog"
+      >
+        <FaArrowLeft
+          className="transition-transform group-hover:-translate-x-1"
+          size={12}
+        />
+        Blog
+      </Link>
+
+      <header className="mt-8 border-b border-default-200 pb-8">
+        <div className="flex items-center gap-3 font-mono text-xs text-default-400">
+          <span>{formatDate(post.date)}</span>
+          <span className="h-px w-4 bg-default-300" />
+          <span>{post.readingTime}</span>
+        </div>
+        <h1 className="mt-4 text-3xl font-semibold leading-tight tracking-tight text-foreground sm:text-4xl">
+          {post.title}
+        </h1>
+        <div className="mt-5 flex flex-wrap gap-2">
+          {post.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-md border border-default-200 bg-default-100/60 px-2 py-0.5 font-mono text-xs text-default-500"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </header>
+
+      <div className="mt-10">
+        <Content />
+      </div>
+
+      <footer className="mt-16 border-t border-default-200 pt-8">
+        <p className="text-default-500">
+          Found this useful, or hit a variation of it?{" "}
+          <Link className="text-primary" href="/#contact">
+            Let me know
+          </Link>
+          .
+        </p>
+      </footer>
+    </article>
+  );
+}

--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -4,10 +4,8 @@ export default function BlogLayout({
   children: React.ReactNode;
 }) {
   return (
-    <section className="flex flex-col items-center justify-center gap-4 py-8 md:py-10">
-      <div className="inline-block max-w-lg text-center justify-center">
-        {children}
-      </div>
+    <section className="mx-auto w-full max-w-5xl px-6 py-14 sm:py-20">
+      {children}
     </section>
   );
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,9 +1,61 @@
-import { title } from "@/components/primitives";
+import { Metadata } from "next";
+import { Link } from "@nextui-org/link";
+
+import { sortedPosts, formatDate } from "@/config/posts";
+
+export const metadata: Metadata = {
+  title: "Blog",
+  description:
+    "Notes on building software, self-hosting, debugging, and the occasional hard-won fix.",
+};
 
 export default function BlogPage() {
   return (
     <div>
-      <h1 className={title()}>Blog</h1>
+      <header className="max-w-2xl">
+        <p className="font-mono text-xs uppercase tracking-[0.18em] text-primary">
+          Blog
+        </p>
+        <h1 className="mt-3 text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
+          Writing
+        </h1>
+        <p className="mt-4 text-lg text-default-500">
+          Notes on building software, self-hosting, and debugging — written down
+          so the next person (often future me) doesn&apos;t have to rediscover
+          it.
+        </p>
+      </header>
+
+      <div className="mt-12 divide-y divide-default-200 border-y border-default-200">
+        {sortedPosts.map((post) => (
+          <article key={post.slug}>
+            <Link
+              className="group flex flex-col gap-3 px-1 py-8"
+              href={`/blog/${post.slug}`}
+            >
+              <div className="flex items-center gap-3 font-mono text-xs text-default-400">
+                <span>{formatDate(post.date)}</span>
+                <span className="h-px w-4 bg-default-300" />
+                <span>{post.readingTime}</span>
+              </div>
+              <h2 className="text-2xl font-semibold text-foreground transition-colors group-hover:text-primary">
+                {post.title}
+              </h2>
+              <p className="max-w-2xl text-default-500">{post.description}</p>
+              <div className="flex flex-wrap gap-2 pt-1">
+                {post.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-md border border-default-200 bg-default-100/60 px-2 py-0.5 font-mono text-xs text-default-500"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </Link>
+          </article>
+        ))}
+      </div>
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,29 +1,40 @@
 import "@/styles/globals.css";
 import { Metadata, Viewport } from "next";
-import { Link } from "@nextui-org/link";
 import clsx from "clsx";
 
 import { Providers } from "./providers";
 
 import { siteConfig } from "@/config/site";
-import { fontSans } from "@/config/fonts";
+import { fontSans, fontMono } from "@/config/fonts";
 import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
 
 export const metadata: Metadata = {
+  metadataBase: new URL(siteConfig.url),
   title: {
-    default: siteConfig.name,
-    template: `%s - ${siteConfig.name}`,
+    default: siteConfig.title,
+    template: `%s — ${siteConfig.name}`,
   },
   description: siteConfig.description,
-  icons: {
-    icon: "/favicon.ico",
+  openGraph: {
+    title: siteConfig.title,
+    description: siteConfig.description,
+    url: siteConfig.url,
+    siteName: siteConfig.name,
+    type: "website",
   },
+  twitter: {
+    card: "summary_large_image",
+    title: siteConfig.title,
+    description: siteConfig.description,
+  },
+  icons: { icon: "/favicon.ico" },
 };
 
 export const viewport: Viewport = {
   themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "white" },
-    { media: "(prefers-color-scheme: dark)", color: "black" },
+    { media: "(prefers-color-scheme: light)", color: "#faf9f7" },
+    { media: "(prefers-color-scheme: dark)", color: "#0a0c0f" },
   ],
 };
 
@@ -39,25 +50,14 @@ export default function RootLayout({
         className={clsx(
           "min-h-screen bg-background font-sans antialiased",
           fontSans.variable,
+          fontMono.variable,
         )}
       >
         <Providers themeProps={{ attribute: "class", defaultTheme: "dark" }}>
-          <div className="relative flex flex-col h-screen">
+          <div className="relative flex min-h-screen flex-col">
             <Navbar />
-            <main className="container mx-auto max-w-7xl pt-16 px-6 flex-grow">
-              {children}
-            </main>
-            <footer className="w-full flex items-center justify-center py-3">
-              <Link
-                isExternal
-                className="flex items-center gap-1 text-current"
-                href="https://nextui-docs-v2.vercel.app?utm_source=next-app-template"
-                title="nextui.org homepage"
-              >
-                <span className="text-default-600">Powered by</span>
-                <p className="text-primary">NextUI</p>
-              </Link>
-            </footer>
+            <main className="flex-grow">{children}</main>
+            <Footer />
           </div>
         </Providers>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,20 +1,19 @@
-"use client";
-import Contact from "@/components/contact";
+import Hero from "@/components/Hero";
 import Skills from "@/components/skills";
 import Projects from "@/components/projects";
-import Hero from "@/components/Hero";
+import Writing from "@/components/writing";
+import Contact from "@/components/contact";
 import BackToTopButton from "@/components/BackToTopButton";
 
 export default function Home() {
   return (
-    <div className="flex flex-col items-center justify-center gap-4 py-8 md:py-10">
-      <div className="inline-block max-w-3xl text-center justify-center">
-        <Hero />
-        <Skills />
-        <Projects />
-        <Contact />
-        <BackToTopButton />
-      </div>
+    <div className="mx-auto w-full max-w-5xl px-6 pb-16">
+      <Hero />
+      <Skills />
+      <Projects />
+      <Writing />
+      <Contact />
+      <BackToTopButton />
     </div>
   );
 }

--- a/components/BackToTopButton.tsx
+++ b/components/BackToTopButton.tsx
@@ -1,3 +1,4 @@
+"use client";
 import React, { useState, useEffect } from "react";
 import { FaArrowUp } from "react-icons/fa";
 

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,101 +1,86 @@
-import React from "react";
-import { Card, CardBody, Button, Link } from "@nextui-org/react";
-import { FaGithub, FaLinkedinIn, FaMapMarkerAlt } from "react-icons/fa";
-import { BsBriefcase } from "react-icons/bs";
+import { Button } from "@nextui-org/button";
+import { Link } from "@nextui-org/link";
 import Image from "next/image";
+import { FaGithub, FaLinkedinIn } from "react-icons/fa";
 
-const Hero = ({
-  personalInfo = {
-    name: "Samy Layaida",
-    title: "Full Stack Developer",
-    location: "Paris, France",
-    image: "/images/my_image.jpg",
-    bio: "Passionate about creating efficient, user-friendly applications with modern technologies.",
-    links: {
-      github: "https://github.com/Samylay",
-      linkedin: "https://linkedin.com/in/samy-layaida",
-    },
-    availability: "Open to opportunities",
-  },
-}) => {
+import { siteConfig } from "@/config/site";
+
+const Hero = () => {
   return (
-    <section className="min-h-screen py-16" id="hero">
-      <div className="max-w-4xl mx-auto px-8 ">
-        <Card className="dark:bg-gradient-to-br from-gray-900 to-gray-800 border dark:border-gray-800">
-          <CardBody className="p-8">
-            <div className="flex md:flex-row gap-8 items-center">
-              <div className="w-48 h-48 rounded-full border-4 border-gray-200 dark:border-gray-700 overflow-hidden">
-                <Image
-                  alt="Profile"
-                  className="w-full h-full object-cover"
-                  height={192}
-                  src={personalInfo.image}
-                  width={192}
-                />
-              </div>
+    <section className="pt-10 sm:pt-16" id="top">
+      <div className="flex flex-col-reverse items-start gap-10 sm:flex-row sm:items-center sm:justify-between">
+        <div className="max-w-2xl">
+          <p className="fade-up flex items-center gap-2 font-mono text-xs uppercase tracking-[0.2em] text-primary">
+            <span className="relative flex h-2 w-2">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary/60" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-primary" />
+            </span>
+            Available for new work
+          </p>
 
-              <div className="w-full md:w-2/3 space-y-6">
-                <div>
-                  <h1 className="text-4xl font-bold dark:text-white mb-2">
-                    {personalInfo.name}
-                  </h1>
-                  <p className="text-2xl dark:text-gray-300 mb-2">
-                    {personalInfo.title}
-                  </p>
-                  <p className="text-blue-400 flex items-center gap-2">
-                    <FaMapMarkerAlt size={16} />
-                    {personalInfo.location}
-                  </p>
-                </div>
+          <h1 className="fade-up fade-up-1 mt-5 text-4xl font-semibold leading-[1.05] tracking-tight text-foreground sm:text-6xl">
+            Samy Layaida
+          </h1>
 
-                <div className="space-y-4">
-                  <p className="dark:text-gray-300 text-lg leading-relaxed">
-                    {personalInfo.bio}
-                  </p>
-                  <div className="inline-block px-4 py-2 bg-emerald-500/10 border border-emerald-500/20 rounded-full">
-                    <p className="text-emerald-400 flex items-center gap-2">
-                      <BsBriefcase size={16} />
-                      Currently Employed
-                    </p>
-                  </div>
-                </div>
+          <p className="fade-up fade-up-2 mt-4 text-xl text-default-600 sm:text-2xl">
+            Full-stack software engineer building web apps end to end — and
+            running the homelab they live on.
+          </p>
 
-                <div className="flex flex-wrap gap-3">
-                  <Button
-                    as={Link}
-                    className="dark:bg-gray-800 dark:text-gray-300 dark:hover:text-white group"
-                    href={personalInfo.links.github}
-                    startContent={
-                      <FaGithub
-                        className="dark:group-hover:text-white transition-colors"
-                        size={20}
-                      />
-                    }
-                    target="_blank"
-                    variant="flat"
-                  >
-                    GitHub
-                  </Button>
-                  <Button
-                    as={Link}
-                    className="dark:bg-gray-800 dark:text-gray-300 dark:hover:text-white group"
-                    href={personalInfo.links.linkedin}
-                    startContent={
-                      <FaLinkedinIn
-                        className="dark:group-hover:text-white dark:transition-colors"
-                        size={20}
-                      />
-                    }
-                    target="_blank"
-                    variant="flat"
-                  >
-                    LinkedIn
-                  </Button>
-                </div>
-              </div>
-            </div>
-          </CardBody>
-        </Card>
+          <p className="fade-up fade-up-3 mt-5 max-w-xl text-default-500">
+            Based in Paris. I like shipping small, sharp products, wiring up
+            self-hosted infrastructure, and writing down what I learn along the
+            way. Currently employed and open to interesting problems.
+          </p>
+
+          <div className="fade-up fade-up-4 mt-8 flex flex-wrap items-center gap-3">
+            <Button
+              as={Link}
+              className="font-medium"
+              color="primary"
+              href={siteConfig.links.contact}
+              radius="full"
+              variant="shadow"
+            >
+              Get in touch
+            </Button>
+            <Button
+              isExternal
+              as={Link}
+              href={siteConfig.links.github}
+              radius="full"
+              startContent={<FaGithub size={18} />}
+              variant="bordered"
+            >
+              GitHub
+            </Button>
+            <Button
+              isExternal
+              isIconOnly
+              as={Link}
+              aria-label="LinkedIn"
+              href={siteConfig.links.linkedin}
+              radius="full"
+              variant="bordered"
+            >
+              <FaLinkedinIn size={16} />
+            </Button>
+          </div>
+        </div>
+
+        <div className="fade-up relative h-32 w-32 shrink-0 sm:h-44 sm:w-44">
+          <div className="absolute -inset-2 rounded-full bg-primary/15 blur-2xl" />
+          <div className="relative h-full w-full overflow-hidden rounded-full border border-default-200 ring-1 ring-primary/20">
+            <Image
+              priority
+              alt="Samy Layaida"
+              className="h-full w-full object-cover"
+              height={176}
+              src="/images/my_image.jpg"
+              width={176}
+            />
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/components/contact.tsx
+++ b/components/contact.tsx
@@ -1,28 +1,27 @@
 "use client";
-import React from "react";
 import { useFormik } from "formik";
 import * as Yup from "yup";
-import { Input } from "@nextui-org/input";
+import { Input, Textarea } from "@nextui-org/input";
 import { Select, SelectItem } from "@nextui-org/react";
-import { Textarea } from "@nextui-org/input";
 import { Button } from "@nextui-org/button";
-import { Card, CardBody } from "@nextui-org/react";
+import { Link } from "@nextui-org/link";
+
+import { SectionHeading } from "@/components/section";
+import { siteConfig } from "@/config/site";
 
 const Contact = () => {
   const inquiryTypes = [
-    { label: "Freelance project proposal", value: "hireMe" },
-    { label: "Collaboration", value: "collaboration" },
-    { label: "Feedback", value: "feedback" },
-    { label: "Other", value: "other" },
+    {
+      label: "Freelance project proposal",
+      value: "Freelance project proposal",
+    },
+    { label: "Collaboration", value: "Collaboration" },
+    { label: "Feedback", value: "Feedback" },
+    { label: "Other", value: "Other" },
   ];
 
   const formik = useFormik({
-    initialValues: {
-      firstName: "",
-      email: "",
-      type: "other",
-      comment: "",
-    },
+    initialValues: { firstName: "", email: "", type: "Other", comment: "" },
     validationSchema: Yup.object({
       firstName: Yup.string().required("Required"),
       email: Yup.string().email("Invalid email address").required("Required"),
@@ -32,81 +31,94 @@ const Contact = () => {
         .required("Required"),
     }),
     onSubmit: (values) => {
-      const emailBody = `${values.comment}`.trim();
+      const subject = `${values.type} — ${values.firstName}`;
+      const body = `${values.comment}\n\n— ${values.firstName} (${values.email})`;
 
-      const mailtoUrl = `mailto:layaida.samy@gmail.com?subject=${encodeURIComponent(values.type)}&body=${encodeURIComponent(emailBody)}`;
-
-      window.location.href = mailtoUrl;
+      window.location.href = `mailto:layaida.samy@gmail.com?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
     },
   });
 
   return (
-    <section className="min-h-screen py-16" id="contact">
-      <h1 className="text-4xl font-bold dark:text-white mb-8">Contact me</h1>
-      <div className="flex max-w-4xl mx-auto px-8 mt-24">
-        <Card className="w-full">
-          <CardBody className="gap-4">
-            <form className="space-y-6" onSubmit={formik.handleSubmit}>
-              <Input
-                errorMessage={
-                  formik.touched.firstName && formik.errors.firstName
-                }
-                id="firstName"
-                isInvalid={
-                  formik.touched.firstName && !!formik.errors.firstName
-                }
-                label="Name"
-                type="text"
-                variant="bordered"
-                {...formik.getFieldProps("firstName")}
-              />
+    <section className="pt-24 sm:pt-28" id="contact">
+      <SectionHeading eyebrow="Contact" index="04" title="Let's talk" />
+      <div className="grid gap-10 md:grid-cols-[0.9fr_1.1fr]">
+        <div>
+          <p className="text-default-600">
+            Have a project, a role, or an idea worth building? Send a note and
+            I&apos;ll get back to you. You can also reach me directly:
+          </p>
+          <div className="mt-6 flex flex-col gap-3 font-mono text-sm">
+            <Link
+              className="text-default-600 hover:text-primary"
+              href={siteConfig.links.email}
+            >
+              layaida.samy@gmail.com
+            </Link>
+            <Link
+              isExternal
+              className="text-default-600 hover:text-primary"
+              href={siteConfig.links.github}
+            >
+              github.com/Samylay
+            </Link>
+            <Link
+              isExternal
+              className="text-default-600 hover:text-primary"
+              href={siteConfig.links.linkedin}
+            >
+              linkedin.com/in/samy-layaida
+            </Link>
+          </div>
+        </div>
 
-              <Input
-                errorMessage={formik.touched.email && formik.errors.email}
-                id="email"
-                isInvalid={formik.touched.email && !!formik.errors.email}
-                label="Email Address"
-                type="email"
-                variant="bordered"
-                {...formik.getFieldProps("email")}
-              />
-
-              <Select
-                defaultSelectedKeys={["other"]}
-                id="type"
-                label="Type of enquiry"
-                variant="bordered"
-                {...formik.getFieldProps("type")}
-              >
-                {inquiryTypes.map((type) => (
-                  <SelectItem key={type.value} value={type.value}>
-                    {type.label}
-                  </SelectItem>
-                ))}
-              </Select>
-
-              <Textarea
-                errorMessage={formik.touched.comment && formik.errors.comment}
-                id="comment"
-                isInvalid={formik.touched.comment && !!formik.errors.comment}
-                label="Your message"
-                minRows={4}
-                variant="bordered"
-                {...formik.getFieldProps("comment")}
-              />
-
-              <Button
-                className="w-full"
-                color="default"
-                size="lg"
-                type="submit"
-                variant="ghost"
-              >
-                Submit
-              </Button>
-            </form>
-          </CardBody>
-        </Card>
+        <form className="space-y-4" onSubmit={formik.handleSubmit}>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Input
+              errorMessage={formik.touched.firstName && formik.errors.firstName}
+              isInvalid={formik.touched.firstName && !!formik.errors.firstName}
+              label="Name"
+              variant="bordered"
+              {...formik.getFieldProps("firstName")}
+            />
+            <Input
+              errorMessage={formik.touched.email && formik.errors.email}
+              isInvalid={formik.touched.email && !!formik.errors.email}
+              label="Email"
+              type="email"
+              variant="bordered"
+              {...formik.getFieldProps("email")}
+            />
+          </div>
+          <Select
+            defaultSelectedKeys={["Other"]}
+            label="Type of enquiry"
+            variant="bordered"
+            {...formik.getFieldProps("type")}
+          >
+            {inquiryTypes.map((type) => (
+              <SelectItem key={type.value} value={type.value}>
+                {type.label}
+              </SelectItem>
+            ))}
+          </Select>
+          <Textarea
+            errorMessage={formik.touched.comment && formik.errors.comment}
+            isInvalid={formik.touched.comment && !!formik.errors.comment}
+            label="Your message"
+            minRows={4}
+            variant="bordered"
+            {...formik.getFieldProps("comment")}
+          />
+          <Button
+            color="primary"
+            radius="full"
+            size="lg"
+            type="submit"
+            variant="shadow"
+          >
+            Send message
+          </Button>
+        </form>
       </div>
     </section>
   );

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,0 +1,49 @@
+import { Link } from "@nextui-org/link";
+
+import { siteConfig } from "@/config/site";
+import { GithubIcon } from "@/components/icons";
+
+export function Footer() {
+  return (
+    <footer className="mt-24 border-t border-default-200/60">
+      <div className="mx-auto flex max-w-5xl flex-col items-start justify-between gap-4 px-6 py-10 sm:flex-row sm:items-center">
+        <div>
+          <p className="font-mono text-sm text-foreground">Samy Layaida</p>
+          <p className="mt-1 text-sm text-default-500">
+            Software engineer · Paris · building &amp; self-hosting
+          </p>
+        </div>
+        <div className="flex items-center gap-5 text-sm text-default-500">
+          <Link
+            isExternal
+            className="text-default-500 hover:text-primary"
+            href={siteConfig.links.github}
+          >
+            <span className="flex items-center gap-1.5">
+              <GithubIcon size={18} /> GitHub
+            </span>
+          </Link>
+          <Link
+            isExternal
+            className="text-default-500 hover:text-primary"
+            href={siteConfig.links.linkedin}
+          >
+            LinkedIn
+          </Link>
+          <Link
+            className="text-default-500 hover:text-primary"
+            href={siteConfig.links.email}
+          >
+            Email
+          </Link>
+        </div>
+      </div>
+      <div className="mx-auto max-w-5xl px-6 pb-8">
+        <p className="font-mono text-xs text-default-400">
+          © {new Date().getFullYear()} Samy Layaida — built with Next.js,
+          deployed on Vercel.
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,55 +1,100 @@
+"use client";
+
 import {
   Navbar as NextUINavbar,
   NavbarContent,
   NavbarBrand,
   NavbarItem,
+  NavbarMenu,
+  NavbarMenuItem,
+  NavbarMenuToggle,
 } from "@nextui-org/navbar";
-import { Button } from "@nextui-org/button";
 import { Link } from "@nextui-org/link";
 import NextLink from "next/link";
+import { usePathname } from "next/navigation";
+import { useState } from "react";
+import clsx from "clsx";
 
 import { siteConfig } from "@/config/site";
 import { ThemeSwitch } from "@/components/theme-switch";
 import { GithubIcon, Logo } from "@/components/icons";
 
 export const Navbar = () => {
+  const pathname = usePathname();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const isActive = (href: string) =>
+    href.startsWith("/#") ? pathname === "/" : pathname.startsWith(href);
+
   return (
-    <NextUINavbar maxWidth="xl" position="sticky">
-      <NavbarContent className="basis-1/5 sm:basis-full" justify="start">
-        <NavbarBrand as="button" className="gap-3 max-w-fit">
-          <NextLink className="flex justify-start items-center gap-1" href="/">
+    <NextUINavbar
+      isBordered
+      classNames={{ base: "bg-background/70 backdrop-blur-md" }}
+      isMenuOpen={isMenuOpen}
+      maxWidth="lg"
+      position="sticky"
+      onMenuOpenChange={setIsMenuOpen}
+    >
+      <NavbarContent justify="start">
+        <NavbarBrand className="max-w-fit">
+          <NextLink
+            className="flex items-center gap-2 text-primary"
+            href="/"
+            onClick={() => setIsMenuOpen(false)}
+          >
             <Logo />
-            <p className="font-bold text-inherit">Samy Layaida</p>
+            <span className="font-mono text-sm font-semibold tracking-tight text-foreground">
+              samy<span className="text-primary">.</span>layaida
+            </span>
           </NextLink>
         </NavbarBrand>
       </NavbarContent>
 
-      <NavbarContent
-        className="hidden sm:flex basis-1/5 sm:basis-full"
-        justify="end"
-      >
-        <NavbarItem className="hidden md:flex">
-          <Button
-            as={Link}
-            className="text-sm font-normal text-default-600 bg-default-100"
-            href={siteConfig.links.contact}
-            // startContent={< className="text-danger" />}
-            variant="flat"
-          >
-            Get in touch!
-          </Button>
-        </NavbarItem>
-        <NavbarItem className="hidden sm:flex gap-2 pl-4">
-          <ThemeSwitch />
-        </NavbarItem>
+      <NavbarContent className="hidden gap-7 sm:flex" justify="center">
+        {siteConfig.navItems.map((item) => (
+          <NavbarItem key={item.href} isActive={isActive(item.href)}>
+            <Link
+              className={clsx(
+                "font-mono text-sm",
+                isActive(item.href) ? "text-primary" : "text-default-600",
+              )}
+              href={item.href}
+            >
+              {item.label}
+            </Link>
+          </NavbarItem>
+        ))}
       </NavbarContent>
 
-      <NavbarContent className="sm:hidden basis-1 pl-4" justify="end">
-        <Link isExternal aria-label="Github" href={siteConfig.links.github}>
-          <GithubIcon className="text-default-500" />
-        </Link>
-        <ThemeSwitch />
+      <NavbarContent justify="end">
+        <NavbarItem className="flex items-center gap-3">
+          <Link
+            isExternal
+            aria-label="GitHub"
+            className="text-default-500 hover:text-primary"
+            href={siteConfig.links.github}
+          >
+            <GithubIcon size={20} />
+          </Link>
+          <ThemeSwitch />
+        </NavbarItem>
+        <NavbarMenuToggle className="sm:hidden" />
       </NavbarContent>
+
+      <NavbarMenu className="bg-background/95 pt-6">
+        {siteConfig.navItems.map((item) => (
+          <NavbarMenuItem key={item.href}>
+            <Link
+              className="w-full font-mono text-lg text-foreground"
+              href={item.href}
+              size="lg"
+              onClick={() => setIsMenuOpen(false)}
+            >
+              {item.label}
+            </Link>
+          </NavbarMenuItem>
+        ))}
+      </NavbarMenu>
     </NextUINavbar>
   );
 };

--- a/components/projects.tsx
+++ b/components/projects.tsx
@@ -1,105 +1,165 @@
-import React from "react";
-import { Card, CardBody, Button, Link } from "@nextui-org/react";
-import { CiGlobe } from "react-icons/ci";
-import { FaGithub } from "react-icons/fa";
-const Projects = ({
-  projects = [
-    {
-      title: "Mock project",
-      description: "Mock data",
-      image: "/images/Mock.jpg",
-      tech: ["Next.js", "TypeScript"],
-      github: "#",
-      live: "#",
-      highlights: ["Mock highlights"],
-    },
-  ],
-}) => {
+import { Link } from "@nextui-org/link";
+import { FaGithub, FaArrowRight } from "react-icons/fa";
+import { FiExternalLink } from "react-icons/fi";
+
+import { projects, type Project } from "@/config/projects";
+import { SectionHeading, Reveal } from "@/components/section";
+
+function StatusPill({ status }: { status: Project["status"] }) {
+  const tone =
+    status === "Live"
+      ? "text-emerald-500 border-emerald-500/30 bg-emerald-500/10"
+      : status === "Self-hosted"
+        ? "text-primary border-primary/30 bg-primary/10"
+        : status === "Archived"
+          ? "text-default-500 border-default-300 bg-default-100"
+          : "text-amber-500 border-amber-500/30 bg-amber-500/10";
+
   return (
-    <section className="min-h-screen py-16" id="projects">
-      <div className="max-w-4xl mx-auto px-8">
-        <h2 className="text-4xl font-bold dark:text-white mb-8">
-          Featured Projects
-        </h2>
-        <div className="space-y-8">
-          {projects.map((project) => (
-            <Card
-              key={project.title}
-              className="dark:bg-gray-900 border dark:border-gray-800"
+    <span
+      className={`rounded-full border px-2.5 py-0.5 font-mono text-[0.68rem] uppercase tracking-wide ${tone}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function Tech({ tech }: { tech: string[] }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {tech.map((t) => (
+        <span
+          key={t}
+          className="rounded-md border border-default-200 bg-default-100/60 px-2.5 py-1 font-mono text-xs text-default-600"
+        >
+          {t}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function ProjectLinks({ project }: { project: Project }) {
+  return (
+    <div className="flex items-center gap-4 text-sm">
+      {project.github && (
+        <Link
+          isExternal
+          className="flex items-center gap-1.5 text-default-600 hover:text-primary"
+          href={project.github}
+        >
+          <FaGithub size={16} /> Code
+        </Link>
+      )}
+      {project.live && (
+        <Link
+          isExternal
+          className="flex items-center gap-1.5 text-default-600 hover:text-primary"
+          href={project.live}
+        >
+          <FiExternalLink size={16} /> Live
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function FeaturedCard({ project }: { project: Project }) {
+  return (
+    <div className="group relative overflow-hidden rounded-3xl border border-default-200 bg-gradient-to-br from-default-50 to-default-100/40 p-8 transition-colors hover:border-primary/40 sm:p-10">
+      <div className="pointer-events-none absolute -right-16 -top-16 h-56 w-56 rounded-full bg-primary/10 blur-3xl transition-opacity group-hover:opacity-80" />
+      <div className="relative">
+        <div className="flex items-center gap-3">
+          <span className="font-mono text-xs uppercase tracking-[0.16em] text-primary">
+            Featured
+          </span>
+          <StatusPill status={project.status} />
+          <span className="font-mono text-xs text-default-400">
+            {project.year}
+          </span>
+        </div>
+        <h3 className="mt-4 text-3xl font-semibold tracking-tight text-foreground">
+          {project.title}
+        </h3>
+        <p className="mt-1 text-lg text-primary">{project.tagline}</p>
+        <p className="mt-4 max-w-2xl text-default-600">{project.description}</p>
+        <ul className="mt-5 grid gap-2 sm:grid-cols-3">
+          {project.highlights.map((h) => (
+            <li
+              key={h}
+              className="flex items-start gap-2 text-sm text-default-600"
             >
-              <CardBody className="p-0">
-                <div className="relative">
-                  <img
-                    alt={project.title}
-                    className="w-full h-64 object-cover"
-                    src={project.image}
-                  />
-                  <div className="absolute inset-0 bg-gradient-to-b from-transparent to-gray-300/90 dark:to-gray-900/90" />
-                </div>
+              <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary" />
+              {h}
+            </li>
+          ))}
+        </ul>
+        <div className="mt-7 flex flex-wrap items-center justify-between gap-4">
+          <Tech tech={project.tech} />
+          <ProjectLinks project={project} />
+        </div>
+      </div>
+    </div>
+  );
+}
 
-                <div className="p-6 space-y-4">
-                  <div className="flex justify-between items-start">
-                    <h3 className="text-2xl font-bold dark:text-white">
-                      {project.title}
-                    </h3>
-                    <div className="flex gap-2">
-                      <Button
-                        isIconOnly
-                        as={Link}
-                        className="dark:bg-gray-800 dark:text-gray-300 dark:hover:text-white"
-                        href={project.github}
-                        target="_blank"
-                        variant="flat"
-                      >
-                        <FaGithub className="w-5 h-5" />
-                      </Button>
-                      <Button
-                        isIconOnly
-                        as={Link}
-                        className="dark:bg-gray-800 dark:text-gray-300 dark:hover:text-white"
-                        href={project.live}
-                        target="_blank"
-                        variant="flat"
-                      >
-                        <CiGlobe className="w-5 h-5" />
-                      </Button>
-                    </div>
-                  </div>
+function ProjectCard({ project }: { project: Project }) {
+  return (
+    <div className="group flex h-full flex-col rounded-2xl border border-default-200 bg-default-50/50 p-6 transition-colors hover:border-primary/40">
+      <div className="flex items-center justify-between">
+        <StatusPill status={project.status} />
+        <span className="font-mono text-xs text-default-400">
+          {project.year}
+        </span>
+      </div>
+      <h3 className="mt-4 text-xl font-semibold text-foreground">
+        {project.title}
+      </h3>
+      <p className="mt-1 text-sm text-primary">{project.tagline}</p>
+      <p className="mt-3 flex-grow text-sm text-default-600">
+        {project.description}
+      </p>
+      <div className="mt-5 space-y-4">
+        <Tech tech={project.tech} />
+        <ProjectLinks project={project} />
+      </div>
+    </div>
+  );
+}
 
-                  <p className="dark:text-gray-300">{project.description}</p>
+const Projects = () => {
+  const featured = projects.find((p) => p.featured);
+  const rest = projects.filter((p) => !p.featured);
 
-                  <div>
-                    <h4 className="dark:text-white font-semibold mb-2">
-                      Key Features:
-                    </h4>
-                    <ul className="space-y-1">
-                      {project.highlights.map((highlight) => (
-                        <li
-                          key={highlight}
-                          className="dark:text-gray-300 flex items-center space-x-2"
-                        >
-                          <span className="w-1.5 h-1.5 bg-blue-500 rounded-full" />
-                          <span>{highlight}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-
-                  <div className="flex flex-wrap gap-2 pt-2">
-                    {project.tech.map((tech) => (
-                      <span
-                        key={tech}
-                        className="px-3 py-1 dark:bg-gray-800 dark:text-gray-300 rounded-full text-sm border border-gray-400 dark:border-gray-700"
-                      >
-                        {tech}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              </CardBody>
-            </Card>
+  return (
+    <section className="pt-24 sm:pt-28" id="work">
+      <SectionHeading eyebrow="Work" index="02" title="Selected projects" />
+      <div className="space-y-6">
+        {featured && (
+          <Reveal>
+            <FeaturedCard project={featured} />
+          </Reveal>
+        )}
+        <div className="grid gap-6 md:grid-cols-3">
+          {rest.map((project, i) => (
+            <Reveal key={project.title} delay={i * 0.08}>
+              <ProjectCard project={project} />
+            </Reveal>
           ))}
         </div>
+      </div>
+      <div className="mt-8">
+        <Link
+          isExternal
+          className="group inline-flex items-center gap-2 font-mono text-sm text-default-600 hover:text-primary"
+          href="https://github.com/Samylay?tab=repositories"
+        >
+          More on GitHub
+          <FaArrowRight
+            className="transition-transform group-hover:translate-x-1"
+            size={13}
+          />
+        </Link>
       </div>
     </section>
   );

--- a/components/prose.tsx
+++ b/components/prose.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+
+export function Prose({ children }: { children: React.ReactNode }) {
+  return <div className="prose">{children}</div>;
+}
+
+type CalloutTone = "note" | "fix" | "warn";
+
+const toneStyles: Record<CalloutTone, string> = {
+  note: "border-primary/50",
+  fix: "border-emerald-500/60",
+  warn: "border-amber-500/60",
+};
+
+const toneLabel: Record<CalloutTone, string> = {
+  note: "Note",
+  fix: "If it still fails",
+  warn: "Heads up",
+};
+
+export function Callout({
+  tone = "note",
+  label,
+  children,
+}: {
+  tone?: CalloutTone;
+  label?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className={`my-6 rounded-xl border border-default-200 border-l-[3px] ${toneStyles[tone]} bg-default-50/60 px-5 py-4`}
+    >
+      <span className="mb-1 block font-mono text-[0.68rem] uppercase tracking-[0.14em] text-default-500">
+        {label ?? toneLabel[tone]}
+      </span>
+      <div className="text-default-700 [&>p]:my-1">{children}</div>
+    </div>
+  );
+}
+
+/** A faux-terminal block. Pass lines; prefix with markers for colour. */
+export function Terminal({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="my-6 overflow-x-auto rounded-xl border border-[#1b2430] bg-[#0a0e13] p-4">
+      <pre className="m-0 font-mono text-[0.8rem] leading-relaxed text-[#cdd9e6]">
+        {children}
+      </pre>
+    </div>
+  );
+}
+
+export const T = {
+  c: ({ children }: { children: React.ReactNode }) => (
+    <span className="text-[#5f6f82]">{children}</span>
+  ),
+  p: ({ children }: { children: React.ReactNode }) => (
+    <span className="text-[#3fd0dd]">{children}</span>
+  ),
+  bad: ({ children }: { children: React.ReactNode }) => (
+    <span className="text-[#ef6b6b]">{children}</span>
+  ),
+  good: ({ children }: { children: React.ReactNode }) => (
+    <span className="text-[#4cc47e]">{children}</span>
+  ),
+};

--- a/components/section.tsx
+++ b/components/section.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import React from "react";
+import { motion, useReducedMotion } from "framer-motion";
+
+export function SectionHeading({
+  index,
+  eyebrow,
+  title,
+}: {
+  index: string;
+  eyebrow: string;
+  title: string;
+}) {
+  return (
+    <div className="mb-8">
+      <div className="flex items-center gap-3 font-mono text-xs uppercase tracking-[0.18em] text-primary">
+        <span>{index}</span>
+        <span className="h-px w-8 bg-primary/50" />
+        <span className="text-default-500">{eyebrow}</span>
+      </div>
+      <h2 className="mt-3 text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+        {title}
+      </h2>
+    </div>
+  );
+}
+
+export function Reveal({
+  children,
+  delay = 0,
+  className,
+}: {
+  children: React.ReactNode;
+  delay?: number;
+  className?: string;
+}) {
+  const reduce = useReducedMotion();
+
+  if (reduce) return <div className={className}>{children}</div>;
+
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, y: 18 }}
+      transition={{ duration: 0.5, delay, ease: [0.22, 1, 0.36, 1] }}
+      viewport={{ once: true, margin: "-80px" }}
+      whileInView={{ opacity: 1, y: 0 }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/components/skills.tsx
+++ b/components/skills.tsx
@@ -1,51 +1,51 @@
-import React from "react";
-import { Card, CardBody } from "@nextui-org/react";
+import { SectionHeading, Reveal } from "@/components/section";
 
-const Skills = ({
-  skills = [
-    {
-      category: "Frontend",
-      items: ["React", "Tailwind CSS", "JavaScript"],
-    },
-    {
-      category: "Backend",
-      items: ["PHP Symfony", "PostgreSQL", "MongoDB"],
-    },
-    {
-      category: "Tools & Others",
-      items: ["Git", "Docker", "Cypress"],
-    },
-  ],
-}) => {
+const skills = [
+  {
+    category: "Frontend",
+    items: ["TypeScript", "React", "Next.js", "Angular", "Tailwind CSS"],
+  },
+  {
+    category: "Backend",
+    items: ["Node.js", "PHP / Symfony", "PostgreSQL", "MongoDB", "SQLite"],
+  },
+  {
+    category: "Infra & Tooling",
+    items: [
+      "Docker",
+      "Self-hosting",
+      "Cloudflare",
+      "Prometheus + Grafana",
+      "Git",
+    ],
+  },
+];
+
+const Skills = () => {
   return (
-    <section className="min-h-screen py-16" id="skils">
-      <div className="max-w-4xl mx-auto px-8">
-        <h2 className="text-4xl font-bold dark:text-white mb-8">
-          Technical Skills
-        </h2>
-        <Card className="dark:bg-gray-900 grid gap-6 p-6">
-          {skills.map((skillGroup) => (
-            <CardBody
-              key={skillGroup.category}
-              className="border dark:border-gray-800 bg-gray-100/50 dark:bg-gray-900/50 p-6 rounded-lg transform transition-transform duration-300 hover:scale-105"
-            >
-              <h3 className="font-semibold dark:text-white mb-4 border-b dark:border-gray-700 pb-2">
-                {skillGroup.category}
+    <section className="pt-24 sm:pt-28" id="stack">
+      <SectionHeading eyebrow="Stack" index="01" title="What I build with" />
+      <div className="grid gap-4 sm:grid-cols-3">
+        {skills.map((group, i) => (
+          <Reveal key={group.category} delay={i * 0.08}>
+            <div className="h-full rounded-2xl border border-default-200 bg-default-50/50 p-6 transition-colors hover:border-primary/40">
+              <h3 className="font-mono text-xs uppercase tracking-[0.14em] text-default-500">
+                {group.category}
               </h3>
-              <ul className="space-y-2">
-                {skillGroup.items.map((skill) => (
+              <ul className="mt-4 space-y-2.5">
+                {group.items.map((item) => (
                   <li
-                    key={skill}
-                    className="dark:text-gray-300 flex items-center space-x-2"
+                    key={item}
+                    className="flex items-center gap-2.5 text-default-700"
                   >
-                    <span className="w-2 h-2 bg-primary-200 rounded-full" />
-                    <span>{skill}</span>
+                    <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+                    {item}
                   </li>
                 ))}
               </ul>
-            </CardBody>
-          ))}
-        </Card>
+            </div>
+          </Reveal>
+        ))}
       </div>
     </section>
   );

--- a/components/writing.tsx
+++ b/components/writing.tsx
@@ -1,0 +1,55 @@
+import { Link } from "@nextui-org/link";
+import { FaArrowRight } from "react-icons/fa";
+
+import { sortedPosts, formatDate } from "@/config/posts";
+import { SectionHeading, Reveal } from "@/components/section";
+
+const Writing = () => {
+  const recent = sortedPosts.slice(0, 3);
+
+  return (
+    <section className="pt-24 sm:pt-28" id="writing">
+      <SectionHeading eyebrow="Blog" index="03" title="Writing" />
+      <div className="divide-y divide-default-200 border-y border-default-200">
+        {recent.map((post, i) => (
+          <Reveal key={post.slug} delay={i * 0.06}>
+            <Link
+              className="group flex flex-col gap-2 px-1 py-6 sm:flex-row sm:items-baseline sm:gap-6"
+              href={`/blog/${post.slug}`}
+            >
+              <span className="shrink-0 font-mono text-xs text-default-400 sm:w-28">
+                {formatDate(post.date)}
+              </span>
+              <span className="flex-grow">
+                <span className="text-lg font-medium text-foreground transition-colors group-hover:text-primary">
+                  {post.title}
+                </span>
+                <span className="mt-1 block text-sm text-default-500">
+                  {post.description}
+                </span>
+              </span>
+              <FaArrowRight
+                className="hidden shrink-0 text-default-400 transition-all group-hover:translate-x-1 group-hover:text-primary sm:mt-1 sm:block"
+                size={13}
+              />
+            </Link>
+          </Reveal>
+        ))}
+      </div>
+      <div className="mt-6">
+        <Link
+          className="group inline-flex items-center gap-2 font-mono text-sm text-default-600 hover:text-primary"
+          href="/blog"
+        >
+          All posts
+          <FaArrowRight
+            className="transition-transform group-hover:translate-x-1"
+            size={13}
+          />
+        </Link>
+      </div>
+    </section>
+  );
+};
+
+export default Writing;

--- a/config/posts.ts
+++ b/config/posts.ts
@@ -1,0 +1,41 @@
+import type { ComponentType } from "react";
+
+import EduroamPost from "@/content/posts/graphene-eduroam-fix";
+
+export type Post = {
+  slug: string;
+  title: string;
+  description: string;
+  date: string; // ISO
+  readingTime: string;
+  tags: string[];
+  Content: ComponentType;
+};
+
+export const posts: Post[] = [
+  {
+    slug: "graphene-eduroam-empty-anonymous-identity",
+    title:
+      "eduroam won't connect on your Pixel? Check the Anonymous Identity field",
+    description:
+      "A GrapheneOS eduroam profile can look perfectly configured and still fail — the Wi-Fi associates, then authentication silently times out. Here's how to prove it over ADB and fix it with one field.",
+    date: "2026-07-10",
+    readingTime: "6 min read",
+    tags: ["GrapheneOS", "Networking", "802.1X", "Debugging"],
+    Content: EduroamPost,
+  },
+];
+
+export const sortedPosts = [...posts].sort((a, b) =>
+  b.date.localeCompare(a.date),
+);
+
+export const getPost = (slug: string) => posts.find((p) => p.slug === slug);
+
+export function formatDate(iso: string) {
+  return new Date(iso + "T00:00:00").toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}

--- a/config/projects.ts
+++ b/config/projects.ts
@@ -1,0 +1,78 @@
+export type Project = {
+  title: string;
+  tagline: string;
+  description: string;
+  year: string;
+  status: "Live" | "Self-hosted" | "Active" | "Archived";
+  tech: string[];
+  highlights: string[];
+  github?: string;
+  live?: string;
+  featured?: boolean;
+};
+
+export const projects: Project[] = [
+  {
+    title: "LifeOS",
+    tagline:
+      "A single hub for health, fitness, work, and everything in between",
+    description:
+      "A personal operating system that pulls the scattered parts of daily life — training, habits, tasks, notes, finances — into one self-hosted dashboard. Built to replace a dozen apps with one surface I actually control, running on my own homelab.",
+    year: "2026",
+    status: "Self-hosted",
+    tech: ["Next.js", "TypeScript", "PostgreSQL", "Docker", "Tailwind"],
+    highlights: [
+      "Unified dashboard aggregating health, tasks and finances",
+      "Self-hosted on a homelab behind a Cloudflare tunnel",
+      "Containerised deploy with Postgres persistence",
+    ],
+    github: "https://github.com/Samylay/LifeOS",
+    featured: true,
+  },
+  {
+    title: "Layaida — École",
+    tagline: "An e-learning platform for a growing school",
+    description:
+      "A full e-learning MVP: courses, lessons and student progress, shipped as a Next.js app with a lightweight SQLite backend and deployed to production behind a tunnel. Fast to iterate, cheap to run.",
+    year: "2026",
+    status: "Live",
+    tech: ["Next.js", "TypeScript", "SQLite", "Tailwind"],
+    highlights: [
+      "Course and lesson management with student progress",
+      "Server-rendered Next.js with an embedded SQLite store",
+      "Running in production at ecole.samylayaida.com",
+    ],
+    github: "https://github.com/Samylay/Ecole",
+    live: "https://ecole.samylayaida.com",
+  },
+  {
+    title: "TrackIt",
+    tagline: "A habit tracker built on a floor you can always hit",
+    description:
+      "A habit tracker built on the atomic-habits idea that every habit needs a minimum floor you can hit no matter how tired or busy you are. Tap once to log it; if you have more in you, keep going and unlock the next milestone.",
+    year: "2026",
+    status: "Active",
+    tech: ["React", "TypeScript", "Tailwind"],
+    highlights: [
+      "One-tap logging with an always-achievable minimum",
+      "Milestone tiers that reward doing more than the floor",
+      "Designed around consistency over intensity",
+    ],
+    github: "https://github.com/Samylay/trackit",
+  },
+  {
+    title: "Strava Dashboard",
+    tagline: "Training performance, read the way an athlete thinks",
+    description:
+      "A training-performance dashboard on top of the Strava API, plus a companion MCP server that exposes the same data to AI tools. Turns raw activity streams into trends that actually inform the next session.",
+    year: "2026",
+    status: "Active",
+    tech: ["TypeScript", "Strava API", "MCP", "Charts"],
+    highlights: [
+      "Activity trends and load from the Strava API",
+      "Companion MCP server for AI-assisted analysis",
+      "Focus on signal over vanity metrics",
+    ],
+    github: "https://github.com/Samylay/strava-dashboard",
+  },
+];

--- a/config/site.ts
+++ b/config/site.ts
@@ -2,9 +2,20 @@ export type SiteConfig = typeof siteConfig;
 
 export const siteConfig = {
   name: "Samy Layaida",
-  description: "Samy Layaida is a software engineer",
+  title: "Samy Layaida — Software Engineer",
+  description:
+    "Full-stack software engineer in Paris. I build web apps end to end and run a self-hosted homelab. Projects, writing, and how to reach me.",
+  url: "https://samylayaida.com",
+  navItems: [
+    { label: "Work", href: "/#work" },
+    { label: "Blog", href: "/blog" },
+    { label: "About", href: "/about" },
+    { label: "Contact", href: "/#contact" },
+  ],
   links: {
     github: "https://github.com/Samylay",
+    linkedin: "https://www.linkedin.com/in/samy-layaida",
+    email: "mailto:layaida.samy@gmail.com",
     contact: "/#contact",
   },
 };

--- a/content/posts/graphene-eduroam-fix.tsx
+++ b/content/posts/graphene-eduroam-fix.tsx
@@ -1,0 +1,149 @@
+import { Prose, Callout, Terminal, T } from "@/components/prose";
+
+export default function EduroamPost() {
+  return (
+    <Prose>
+      <p className="lead">
+        On GrapheneOS and stock Pixels, an eduroam profile can look perfectly
+        configured and still fail: the Wi-Fi associates, then authentication
+        silently times out. On many university accounts the culprit is a single
+        empty field. Here is how to prove it and fix it.
+      </p>
+
+      <h2>The symptom</h2>
+      <p>
+        The network shows <strong>“Saved / Connection failure”</strong> or{" "}
+        <strong>“Can&apos;t connect. Try again later.”</strong> Normal Wi-Fi and
+        mobile data work fine — only eduroam fails. That last part matters: it
+        rules out broken hardware before you even start. The radio{" "}
+        <em>associates</em> with the access point (you briefly see
+        “Connecting…”), then drops after roughly 40&nbsp;seconds, never reaching
+        the four-way handshake or getting an IP.
+      </p>
+
+      <h2>Confirm it&apos;s authentication, not hardware</h2>
+      <p>
+        “It must be a hardware fault” is the common misdiagnosis. A radio fault
+        would break <em>every</em> network. This breaks only at the{" "}
+        <strong>802.1X / EAP</strong> stage — pure software and configuration.
+        With ADB and USB debugging on, you can watch it happen:
+      </p>
+
+      <Terminal>
+        <T.c># Watch the Wi-Fi state machine for the eduroam attempt</T.c>
+        {"\n"}
+        <T.p>adb shell dumpsys wifi</T.p> | grep -i eduroam | tail
+        {"\n\n"}
+        <T.c>
+          # The tell-tale line — associates, then the phone itself bails:
+        </T.c>
+        {"\n"}
+        NETWORK_DISCONNECTION_EVENT ssid:&quot;eduroam&quot;
+        {"\n"}
+        {"   "}reasonCode: 3 <T.bad>locallyGenerated: true</T.bad>
+        {"\n\n"}
+        <T.c># On repeated tries the access point gets blocklisted:</T.c>
+        {"\n"}
+        blockReason=<T.bad>REASON_FAILURE_NO_RESPONSE</T.bad>
+      </Terminal>
+
+      <p>
+        <code>reasonCode 3</code> + <code>locallyGenerated: true</code> about
+        40&nbsp;seconds after associating is an <strong>EAP timeout</strong>:
+        the phone started the login handshake and gave up waiting. A wrong{" "}
+        <em>password</em> fails fast with a rejection — a 40-second stall points
+        at the outer identity / TLS stage instead.
+      </p>
+
+      <Callout label="Blocklist gotcha" tone="warn">
+        <p>
+          After a few failures, Android blocklists those access points for
+          minutes to hours and stops auto-retrying them. So even after you fix
+          the config, auto-reconnect may look dead. Force it: open the network
+          and tap <strong>Connect</strong>, or toggle Wi-Fi off and on.
+        </p>
+      </Callout>
+
+      <h2>The root cause</h2>
+      <p>
+        Open the eduroam profile (Wi-Fi → the network → the pencil →{" "}
+        <strong>Advanced</strong>) and look at{" "}
+        <strong>Anonymous identity</strong>. On a failing Android&nbsp;14+
+        device it&apos;s often <strong>empty</strong>.
+      </p>
+      <p>
+        That empty field <em>is</em> the bug. The anonymous (outer) identity is
+        the cleartext name your phone presents before the encrypted tunnel opens
+        — it&apos;s what eduroam uses to route your login back to your home
+        institution. Many institutions require it to carry the full realm.
+        Leaving it blank is only the pre-Android-14 fallback; on modern Android
+        the server never answers, and you get{" "}
+        <code>REASON_FAILURE_NO_RESPONSE</code>.
+      </p>
+
+      <h2>The fix</h2>
+      <p>
+        Set <strong>Anonymous identity</strong> to your{" "}
+        <strong>full eduroam username, including the realm</strong> — the same{" "}
+        <code>user@institution</code> you use for Identity. Leave everything
+        else as your institution specifies (commonly PEAP / MSCHAPV2, and “Trust
+        on first use” or your institution&apos;s CA + domain).
+      </p>
+      <ol>
+        <li>
+          Open the eduroam network → pencil / <strong>Modify</strong> → expand{" "}
+          <strong>Advanced options</strong>.
+        </li>
+        <li>
+          Type your full <code>user@institution</code> into{" "}
+          <strong>Anonymous identity</strong>.
+        </li>
+        <li>
+          Confirm Identity and password are correct, then <strong>Save</strong>.
+        </li>
+        <li>
+          Tap the network and press <strong>Connect</strong> — don&apos;t wait
+          for auto-reconnect; those APs may still be blocklisted.
+        </li>
+      </ol>
+
+      <p>Within a second or two it should authenticate and pull an IP:</p>
+
+      <Terminal>
+        <T.p>adb shell dumpsys wifi</T.p> | grep &quot;mWifiInfo SSID&quot;
+        {"\n"}
+        SSID: &quot;eduroam&quot;, <T.good>Supplicant state: COMPLETED</T.good>,
+        {"\n"}
+        {"   "}IP: 10.232.221.62 <T.good>... VALIDATED</T.good>
+        {"\n\n"}
+        <T.p>adb shell ping -c2 1.1.1.1</T.p>
+        {"\n"}
+        64 bytes from 1.1.1.1: time=7.1 ms <T.good>0% packet loss</T.good>
+      </Terminal>
+
+      <Callout tone="fix">
+        <p>
+          If the outer identity is set and it still won&apos;t authenticate,
+          check in order: (1) your account is actually enabled for eduroam, not
+          just campus Wi-Fi; (2) CA certificate + Domain match your
+          institution&apos;s published values; (3) try Privacy → “Use device
+          MAC” — a few deployments reject randomized MACs; (4) as a clean reset,
+          Forget the network and re-add it, or use the official geteduroam /
+          eduroam CAT installer, which fills every field correctly.
+        </p>
+      </Callout>
+
+      <h2>Why this happens</h2>
+      <p>
+        eduroam is a roaming federation: when you&apos;re on a host campus (even
+        in another country), your login is relayed back to your <em>home</em>{" "}
+        institution&apos;s server. The outer identity is the address on that
+        envelope. Older Android tolerated a blank or bare outer identity because
+        the phone fell back to the real one; Android&nbsp;14+ tightened this, so
+        a blank field now produces an unroutable request — and a server that
+        simply never replies. One field, carrying the realm, puts the address
+        back on the envelope.
+      </p>
+    </Prose>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,117 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html {
+    scroll-behavior: smooth;
+    scroll-padding-top: 5rem;
+  }
+  ::selection {
+    background-color: rgb(43 185 164 / 0.25);
+  }
+}
+
+/* ── Hero entrance (CSS, JS-independent) ──────────────────── */
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+.fade-up {
+  opacity: 0;
+  animation: fade-up 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+.fade-up-1 {
+  animation-delay: 0.06s;
+}
+.fade-up-2 {
+  animation-delay: 0.14s;
+}
+.fade-up-3 {
+  animation-delay: 0.22s;
+}
+.fade-up-4 {
+  animation-delay: 0.3s;
+}
+@media (prefers-reduced-motion: reduce) {
+  .fade-up {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ── Blog prose ───────────────────────────────────────────── */
+.prose {
+  max-width: 42rem;
+  color: hsl(var(--nextui-default-700));
+  font-size: 1.03rem;
+  line-height: 1.75;
+}
+.prose > * + * {
+  margin-top: 1.15rem;
+}
+.prose .lead {
+  font-size: 1.2rem;
+  line-height: 1.6;
+  color: hsl(var(--nextui-default-600));
+}
+.prose h2 {
+  margin-top: 2.6rem;
+  margin-bottom: 0.2rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: hsl(var(--nextui-foreground));
+  scroll-margin-top: 5rem;
+}
+.prose h3 {
+  margin-top: 1.8rem;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: hsl(var(--nextui-foreground));
+}
+.prose strong {
+  color: hsl(var(--nextui-foreground));
+  font-weight: 600;
+}
+.prose a {
+  color: hsl(var(--nextui-primary));
+  text-underline-offset: 3px;
+  text-decoration: underline;
+  text-decoration-color: hsl(var(--nextui-primary) / 0.4);
+}
+.prose a:hover {
+  text-decoration-color: hsl(var(--nextui-primary));
+}
+.prose code {
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: 0.86em;
+  background: hsl(var(--nextui-default-100));
+  border: 1px solid hsl(var(--nextui-default-200));
+  border-radius: 5px;
+  padding: 0.1em 0.4em;
+}
+.prose ol,
+.prose ul {
+  padding-left: 1.3rem;
+}
+.prose ol {
+  list-style: decimal;
+}
+.prose ul {
+  list-style: disc;
+}
+.prose li {
+  margin-top: 0.4rem;
+  padding-left: 0.2rem;
+}
+.prose li::marker {
+  color: hsl(var(--nextui-primary));
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,12 @@
-import {nextui} from '@nextui-org/theme'
+import { nextui } from "@nextui-org/theme";
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    './components/**/*.{js,ts,jsx,tsx,mdx}',
-    './app/**/*.{js,ts,jsx,tsx,mdx}',
-    './node_modules/@nextui-org/theme/dist/**/*.{js,ts,jsx,tsx}'
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./content/**/*.{js,ts,jsx,tsx,mdx}",
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./node_modules/@nextui-org/theme/dist/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
     extend: {
@@ -16,6 +17,52 @@ module.exports = {
     },
   },
   darkMode: "class",
-  darkMode: "class",
- plugins: [nextui()],
-}
+  plugins: [
+    nextui({
+      themes: {
+        light: {
+          colors: {
+            background: "#faf9f7",
+            foreground: "#16181d",
+            primary: {
+              50: "#effcf9",
+              100: "#c9f4ea",
+              200: "#95e8d7",
+              300: "#5bd4bf",
+              400: "#2bb9a4",
+              500: "#0f9e8b",
+              600: "#0b7d70",
+              700: "#0d645b",
+              800: "#0f4f49",
+              900: "#11423e",
+              DEFAULT: "#0b7d70",
+              foreground: "#ffffff",
+            },
+            focus: "#0f9e8b",
+          },
+        },
+        dark: {
+          colors: {
+            background: "#0a0c0f",
+            foreground: "#e7ebee",
+            primary: {
+              50: "#11423e",
+              100: "#0f4f49",
+              200: "#0d645b",
+              300: "#0b7d70",
+              400: "#0f9e8b",
+              500: "#2bb9a4",
+              600: "#5bd4bf",
+              700: "#95e8d7",
+              800: "#c9f4ea",
+              900: "#effcf9",
+              DEFAULT: "#2bb9a4",
+              foreground: "#04120f",
+            },
+            focus: "#2bb9a4",
+          },
+        },
+      },
+    }),
+  ],
+};


### PR DESCRIPTION
Revamps samylayaida.com from the stock NextUI template into a distinctive, content-real portfolio with a working blog.

## Design
- Teal accent, mono microtype (Fira Code) for eyebrows/tags/dates, left-aligned editorial sections
- Custom NextUI light **and** dark themes with matched primary color scales
- Hero rewritten with a real bio; entrance animation is now pure CSS (visible even if JS never runs)

## Content
- **Skills** grouped by Frontend / Backend / Infra — real stack
- **Projects** are now data-driven (`config/projects.ts`):
  - **LifeOS** — featured
  - **École** — live at ecole.samylayaida.com
  - **TrackIt** and **Strava Dashboard**
- **Blog** — new: list page, per-post routes (`/blog/[slug]`), and reusable prose / terminal / callout components. First post: *eduroam won't connect on your Pixel? Check the Anonymous Identity field.*
- Homepage 'Writing' teaser, a real About page, a real footer, and a nav with active states

## Verified
- `npm run build` passes; all routes prerender (including the blog post)
- Rendered and screenshot-checked home, blog, and post pages locally
- `package-lock.json` intentionally unchanged (dependency set identical to production)

Merging to `main` deploys to production via Vercel; this branch should get a Vercel preview.